### PR TITLE
Product Type Inductively

### DIFF
--- a/src/Evaluation.elm
+++ b/src/Evaluation.elm
@@ -159,40 +159,6 @@ eval env term =
                 ( Err errFst, Err errSnd ) ->
                     Err (errFst ++ errSnd)
 
-        Fst term1 ->
-            let
-                evaledTermResult =
-                    eval env term1
-            in
-            case evaledTermResult of
-                Ok evaledTerm ->
-                    case evaledTerm of
-                        PairValue fst _ ->
-                            Ok fst
-
-                        _ ->
-                            Err [ ExpectedPair ]
-
-                Err err ->
-                    Err err
-
-        Snd term1 ->
-            let
-                evaledTermResult =
-                    eval env term1
-            in
-            case evaledTermResult of
-                Ok evaledTerm ->
-                    case evaledTerm of
-                        PairValue _ snd ->
-                            Ok snd
-
-                        _ ->
-                            Err [ ExpectedPair ]
-
-                Err err ->
-                    Err err
-
         MatchProduct { arg, var0, var1, body } ->
             eval env arg
                 |> Result.andThen

--- a/src/Evaluation.elm
+++ b/src/Evaluation.elm
@@ -189,6 +189,10 @@ eval env term =
                 Err err ->
                     Err err
 
+        MatchProduct { arg, var0, var1, body } ->
+            -- TODO
+            Debug.todo ""
+
         Abstraction var body ->
             Ok (Closure { env = env, var = var, body = body })
 

--- a/src/Example.elm
+++ b/src/Example.elm
@@ -75,6 +75,10 @@ matchProduct0 =
     MatchProduct { arg = Pair n0 n1, var0 = "x", var1 = "y", body = VarUse "x" }
 
 
+matchProduct0Type =
+    infer0 matchProduct0
+
+
 id =
     -- \x -> x
     Abstraction "x" (VarUse "x")
@@ -100,6 +104,23 @@ twist =
     Abstraction
         "tuple"
         (Pair (Snd (VarUse "tuple")) (Fst (VarUse "tuple")))
+
+
+twistMatch =
+    -- \p -> (match-pair p { (pair x y) . (pair y x) })
+    Abstraction
+        "p"
+        (MatchProduct
+            { arg = VarUse "p"
+            , var0 = "x"
+            , var1 = "y"
+            , body = Pair (VarUse "y") (VarUse "x")
+            }
+        )
+
+
+twistMatchType =
+    infer0 twistMatch
 
 
 twistType =

--- a/src/Example.elm
+++ b/src/Example.elm
@@ -100,13 +100,6 @@ dupType =
 
 
 twist =
-    --  \tuple -> (tuple.snd, tuple.fst)
-    Abstraction
-        "tuple"
-        (Pair (Snd (VarUse "tuple")) (Fst (VarUse "tuple")))
-
-
-twistMatch =
     -- \p -> (match-pair p { (pair x y) . (pair y x) })
     Abstraction
         "p"
@@ -117,10 +110,6 @@ twistMatch =
             , body = Pair (VarUse "y") (VarUse "x")
             }
         )
-
-
-twistMatchType =
-    infer0 twistMatch
 
 
 twistType =
@@ -173,15 +162,15 @@ curryType =
 
 
 uncurry =
-    -- \f p -> (f (fst p)) (snd p)
+    -- (fn { f p . (match-pair p { x y . (@ f x y) }) })
     Abstraction "f"
         (Abstraction "p"
-            (Application
-                (Application
-                    (VarUse "f")
-                    (Fst (VarUse "p"))
-                )
-                (Snd (VarUse "p"))
+            (MatchProduct
+                { arg = VarUse "p"
+                , var0 = "x"
+                , var1 = "y"
+                , body = Application (Application (VarUse "f") (VarUse "x")) (VarUse "y")
+                }
             )
         )
 

--- a/src/Example.elm
+++ b/src/Example.elm
@@ -71,6 +71,10 @@ pair1Type =
     infer0 pair1
 
 
+matchProduct0 =
+    MatchProduct { arg = Pair n0 n1, var0 = "x", var1 = "y", body = VarUse "x" }
+
+
 id =
     -- \x -> x
     Abstraction "x" (VarUse "x")

--- a/src/Inference.elm
+++ b/src/Inference.elm
@@ -448,8 +448,46 @@ infer term =
                 generateFreshVar
 
         MatchProduct { arg, var0, var1, body } ->
-            -- TODO
-            Debug.todo ""
+            -- argType0 := infer arg
+            -- varType0 := generateFreshVar
+            -- varType1 := generateFreshVar
+            -- unify (Product varType0 varType1) argType
+            -- updateContext
+            --   (\context ->
+            --     context |> pushVarToContext var0 varType0
+            --                pushVarToContext var1 varType1
+            --   );
+            -- infer body
+            -- updateContext
+            --   (\context ->
+            --     context |> popVarFromContext var1
+            --                popVarFromContext var0
+            --   );
+            State.andThen3
+                (\argType varType0 varType1 ->
+                    State.second
+                        (unify (Product varType0 varType1) argType)
+                        (State.mid
+                            (updateContext0
+                                (\context ->
+                                    context
+                                        |> pushVarToContext var0 varType0
+                                        |> pushVarToContext var1 varType1
+                                )
+                            )
+                            (infer body)
+                            (updateContext0
+                                (\context ->
+                                    context
+                                        |> popVarFromContext var1
+                                        |> popVarFromContext var0
+                                )
+                            )
+                        )
+                )
+                (infer arg)
+                generateFreshVar
+                generateFreshVar
 
         Snd productExp ->
             State.andThen3

--- a/src/Inference.elm
+++ b/src/Inference.elm
@@ -447,6 +447,10 @@ infer term =
                 generateFreshVar
                 generateFreshVar
 
+        MatchProduct { arg, var0, var1, body } ->
+            -- TODO
+            Debug.todo ""
+
         Snd productExp ->
             State.andThen3
                 (\typeProduct0 fstTypeVar0 sndTypeVar0 ->

--- a/src/Inference.elm
+++ b/src/Inference.elm
@@ -420,33 +420,6 @@ infer term =
                 (infer fst)
                 (infer snd)
 
-        Fst productExp ->
-            -- typeProduct0 := infer productExp;
-            -- fstTypeVar0  := generateFreshVar;
-            -- sndTypeVar0  := generateFreshVar;
-            -- typeProduct2 := unify typeProduct0 (Product fstTypeVar0 sndTypeVar0)
-            -- case typeProduct1 of
-            --     Product fstTypeVar1 _ ->
-            --         return fstTypeVar1
-            --     _ ->
-            --         err ExpectedProductType
-            State.andThen3
-                (\typeProduct0 fstTypeVar0 sndTypeVar0 ->
-                    unify typeProduct0 (Product fstTypeVar0 sndTypeVar0)
-                        |> State.andThen
-                            (\typeProduct2 ->
-                                case typeProduct2 of
-                                    Product fstTypeVar1 _ ->
-                                        State.return fstTypeVar1
-
-                                    _ ->
-                                        throwTypeError [ ExpectedProductType ]
-                            )
-                )
-                (infer productExp)
-                generateFreshVar
-                generateFreshVar
-
         MatchProduct { arg, var0, var1, body } ->
             -- argType0 := infer arg
             -- varType0 := generateFreshVar
@@ -486,24 +459,6 @@ infer term =
                         )
                 )
                 (infer arg)
-                generateFreshVar
-                generateFreshVar
-
-        Snd productExp ->
-            State.andThen3
-                (\typeProduct0 fstTypeVar0 sndTypeVar0 ->
-                    unify typeProduct0 (Product fstTypeVar0 sndTypeVar0)
-                        |> State.andThen
-                            (\typeProduct2 ->
-                                case typeProduct2 of
-                                    Product _ sndTypeVar2 ->
-                                        State.return sndTypeVar2
-
-                                    _ ->
-                                        throwTypeError [ ExpectedProductType ]
-                            )
-                )
-                (infer productExp)
                 generateFreshVar
                 generateFreshVar
 

--- a/src/LambdaBasics.elm
+++ b/src/LambdaBasics.elm
@@ -19,6 +19,12 @@ type Term
       -- elim
     | Fst Term
     | Snd Term
+    | MatchProduct
+        { arg : Term
+        , var0 : TermVarName
+        , var1 : TermVarName
+        , body : Term
+        }
       -- ==Function Space==
       -- intro
     | Abstraction TermVarName Term

--- a/src/LambdaBasics.elm
+++ b/src/LambdaBasics.elm
@@ -17,8 +17,6 @@ type Term
       -- intro
     | Pair Term Term
       -- elim
-    | Fst Term
-    | Snd Term
     | MatchProduct
         { arg : Term
         , var0 : TermVarName

--- a/src/Show.elm
+++ b/src/Show.elm
@@ -30,8 +30,17 @@ showTerm term =
             String.concat [ "(second ", showTerm term1, ")" ]
 
         MatchProduct { arg, var0, var1, body } ->
-            -- TODO
-            Debug.todo ""
+            String.concat
+                [ "(match-pair "
+                , showTerm arg
+                , " { (pair "
+                , var0
+                , " "
+                , var1
+                , ") . "
+                , showTerm body
+                , " })"
+                ]
 
         Abstraction var body ->
             -- (fn { x . body })

--- a/src/Show.elm
+++ b/src/Show.elm
@@ -21,14 +21,6 @@ showTerm term =
             -- (pair e1 e2)
             String.concat [ "(pair ", showTerm fst, " ", showTerm snd, ")" ]
 
-        Fst term1 ->
-            -- (first e)
-            String.concat [ "(first ", showTerm term1, ")" ]
-
-        Snd term1 ->
-            -- (second e)
-            String.concat [ "(second ", showTerm term1, ")" ]
-
         MatchProduct { arg, var0, var1, body } ->
             String.concat
                 [ "(match-pair "

--- a/src/Show.elm
+++ b/src/Show.elm
@@ -29,6 +29,10 @@ showTerm term =
             -- (second e)
             String.concat [ "(second ", showTerm term1, ")" ]
 
+        MatchProduct { arg, var0, var1, body } ->
+            -- TODO
+            Debug.todo ""
+
         Abstraction var body ->
             -- (fn { x . body })
             String.concat [ "(fn { ", var, " . ", showTerm body, " })" ]

--- a/src/TermParser.elm
+++ b/src/TermParser.elm
@@ -22,6 +22,7 @@ import Set exposing (Set)
 --   (cons e1 e2)
 -- Bindings Operators
 --   (fn { x . body })
+--   (match-pair pairExp { (pair x y) . body })
 --   (if e { e1 } { e2 })
 --   (sum-case e { (left x) . e1 } { (right y) . e2 })
 --   (nat-loop   n initState { i s . body })
@@ -260,6 +261,14 @@ pair =
         |= Parser.lazy (\() -> term)
 
 
+pairPattern : Parser ( TermVarName, TermVarName )
+pairPattern =
+    Parser.succeed (\x y -> ( x, y ))
+        |. keyword "pair"
+        |= varIntro
+        |= varIntro
+
+
 fst : Parser Term
 fst =
     Parser.succeed Fst
@@ -274,10 +283,28 @@ snd =
         |= Parser.lazy (\() -> term)
 
 
+
+--   (match-pair pairExp { (pair x y) . body })
+
+
 matchProduct : Parser Term
 matchProduct =
-    -- TODO
-    Debug.todo ""
+    Parser.succeed
+        (\arg ( ( var0, var1 ), body ) ->
+            MatchProduct
+                { arg = arg
+                , var0 = var0
+                , var1 = var1
+                , body = body
+                }
+        )
+        |. keyword "match-pair"
+        -- arg
+        |= Parser.lazy (\() -> term)
+        -- body
+        |= binding
+            (paren pairPattern)
+            (Parser.lazy (\() -> term))
 
 
 

--- a/src/TermParser.elm
+++ b/src/TermParser.elm
@@ -125,6 +125,7 @@ operatorTerm =
             , pair
             , snd
             , fst
+            , matchProduct
             , left
             , right
             , sumCase
@@ -271,6 +272,12 @@ snd =
     Parser.succeed Snd
         |. keyword "second"
         |= Parser.lazy (\() -> term)
+
+
+matchProduct : Parser Term
+matchProduct =
+    -- TODO
+    Debug.todo ""
 
 
 

--- a/src/TermParser.elm
+++ b/src/TermParser.elm
@@ -13,8 +13,6 @@ import Set exposing (Set)
 --   $foo
 -- Simple Operators
 --   (pair e e')
---   (first e)
---   (second e)
 --   (@ f x)
 --   (left e)
 --   (right e)
@@ -124,8 +122,6 @@ operatorTerm =
             , application
             , ifThenElse
             , pair
-            , snd
-            , fst
             , matchProduct
             , left
             , right
@@ -267,20 +263,6 @@ pairPattern =
         |. keyword "pair"
         |= varIntro
         |= varIntro
-
-
-fst : Parser Term
-fst =
-    Parser.succeed Fst
-        |. keyword "first"
-        |= Parser.lazy (\() -> term)
-
-
-snd : Parser Term
-snd =
-    Parser.succeed Snd
-        |. keyword "second"
-        |= Parser.lazy (\() -> term)
 
 
 


### PR DESCRIPTION
1. Define `(match-product productExp { (product x y) . body } )` expression that pattern-matches on product expressions
2. Remove `(first e)`, `(second e)`